### PR TITLE
Force min width, add some responsiveness to homepage

### DIFF
--- a/about/css/style.css
+++ b/about/css/style.css
@@ -1,3 +1,7 @@
+#about {
+  padding-top: 50px;
+}
+
 .strong {
   color: #cc002b;
 }
@@ -16,25 +20,33 @@
 }
 
 .cmu-image {
-  margin-top: 10px;
   display: block;
-  top: 20px;
-  height: 89%;
+  height: 88vh;
+  min-height: 650px;
+  max-height: 900px;
+  padding-right: 50px;
   position: absolute;
 }
 
 .intro-back {
-  display: block;
-  position: absolute;
-  width: 690px;
-  transform: translate3d(78%, 32%, 0px);
+  display: flex;
+  height: 88vh;
+  min-height: 650px;
+  max-height: 900px;
+  justify-content: flex-end;
+  position: relative;
+  align-items: center;
+}
+
+.intro-back__inner {
+  flex-basis: 60%;
+  margin-right: 70px;
   background-color: white;
   box-shadow: 0px 35px 78px -23px rgba(0, 0, 0, 0.33);
 }
 
 .intro {
   padding: 80px;
-  text-align: justify;
   background-color: rgba(0, 0, 0, 0.02s);
 }
 

--- a/about/index.html
+++ b/about/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=1150">
   <link
     href="https://fonts.googleapis.com/css?family=Quicksand:300,400,500,700"
     rel="stylesheet"
@@ -14,6 +15,7 @@
   <link href="../css/common-style.css" rel="stylesheet" />
   <link href="../css/icon.css" rel="stylesheet" />
   <link href="css/style.css" rel="stylesheet" />
+  <title>CMU SCS Master's Advisory Committee</title>
 </head>
 <body>
   <aside>
@@ -80,27 +82,29 @@
       <div class="description">
         <img class="cmu-image" src="images/cmu.png" alt="cmu" />
         <div class="intro-back">
-          <div class="intro">
-            <div class="section-title side-title">
-              SCS
-              <span class="strong">Dean's Masters</span> Advisory Committee
-            </div>
-            <br />
-            The committee serves to better student life for
-            <span class="strong">master’s </span>students in the School of
-            Computer Science at<span class="strong">
-              Carnegie Mellon University </span
-            >by providing feedback to the Dean and spearheading initiatives in
-            the following areas
-            <br />
-            <br />
+          <div class="intro-back__inner">
+            <div class="intro">
+              <div class="section-title side-title">
+                SCS
+                <span class="strong">Dean's Masters</span> Advisory Committee
+              </div>
+              <br />
+              The committee serves to better student life for
+              <span class="strong">master’s </span>students in the School of
+              Computer Science at<span class="strong">
+                Carnegie Mellon University </span
+              >by providing feedback to the Dean and spearheading initiatives in
+              the following areas
+              <br />
+              <br />
 
-            <ul class="plus">
-              <li>Resources</li>
-              <li>Mental Health</li>
-              <li>Culture and Atmosphere Academics</li>
-              <li>Interdepartment Communication Personal Wellness</li>
-            </ul>
+              <ul class="plus">
+                <li>Resources</li>
+                <li>Mental Health</li>
+                <li>Culture and Atmosphere Academics</li>
+                <li>Interdepartment Communication Personal Wellness</li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>

--- a/chat/index.html
+++ b/chat/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=1150">
   <link
     href="https://fonts.googleapis.com/css?family=Quicksand:300,400,500,700"
     rel="stylesheet"
@@ -14,6 +15,7 @@
   <link href="../css/common-style.css" rel="stylesheet" />
   <link href="../css/icon.css" rel="stylesheet" />
   <link href="css/style.css" rel="stylesheet" />
+  <title>Chat with Us</title>
 </head>
 <body>
   <aside>

--- a/constitution/index.html
+++ b/constitution/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=1150">
   <link
     href="https://fonts.googleapis.com/css?family=Quicksand:300,400,500,700"
     rel="stylesheet"
@@ -14,6 +15,7 @@
   <link href="../css/common-style.css" rel="stylesheet" />
   <link href="../css/icon.css" rel="stylesheet" />
   <link href="css/style.css" rel="stylesheet" />
+  <title>Constitution</title>
 </head>
 <body>
   <aside>

--- a/contact/index.html
+++ b/contact/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=1150">
   <link
     href="https://fonts.googleapis.com/css?family=Quicksand:300,400,500,700"
     rel="stylesheet"
@@ -14,6 +15,7 @@
   <link href="../css/common-style.css" rel="stylesheet" />
   <link href="../css/icon.css" rel="stylesheet" />
   <link href="css/style.css" rel="stylesheet" />
+  <title>Contact Us</title>
 </head>
 <body>
   <aside>

--- a/css/common-style.css
+++ b/css/common-style.css
@@ -2,6 +2,7 @@ html,
 body {
   height: 100%;
   font-family: "Quicksand", Arial, sans-serif;
+  min-width: 1150px;
 }
 
 ::-webkit-selection {
@@ -56,12 +57,23 @@ ul.plus li::before {
 aside {
   height: 100%;
   width: 20%;
-  padding: 50px;
-  position: fixed;
+  max-height: 1000px;
+  padding: 50px 50px 50px 0;
   text-align: right;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  float: left;
+}
+
+@media (min-width: 1150px) {
+  aside {
+    position: fixed;
+  }
+}
+
+aside ul {
+  padding: 0;
 }
 
 .logo {
@@ -117,7 +129,9 @@ nav ul li a:hover {
 
 .committee-title {
   width: 100%;
+  max-width: 200px;
   line-height: 1.8em;
+  margin-left: auto;
   text-transform: uppercase;
   font-size: 18px;
   vertical-align: bottom;
@@ -146,7 +160,6 @@ aside ul li a {
 }
 
 section {
-  height: 100%;
   padding-top: 20px;
 }
 

--- a/members/index.html
+++ b/members/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=1150">
   <link
     href="https://fonts.googleapis.com/css?family=Quicksand:300,400,500,700"
     rel="stylesheet"
@@ -14,6 +15,7 @@
   <link href="../css/common-style.css" rel="stylesheet" />
   <link href="../css/icon.css" rel="stylesheet" />
   <link href="css/style.css" rel="stylesheet" />
+  <title>Committee Members</title>
 </head>
 <body>
   <aside>

--- a/minutes/index.html
+++ b/minutes/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=1150">
   <link
     href="https://fonts.googleapis.com/css?family=Quicksand:300,400,500,700"
     rel="stylesheet"

--- a/resources/index.html
+++ b/resources/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=1150">
   <link
     href="https://fonts.googleapis.com/css?family=Quicksand:300,400,500,700"
     rel="stylesheet"
@@ -14,6 +15,7 @@
   <link href="../css/common-style.css" rel="stylesheet" />
   <link href="../css/icon.css" rel="stylesheet" />
   <link href="css/style.css" rel="stylesheet" />
+  <title>Resources</title>
 </head>
 <body>
   <aside>


### PR DESCRIPTION
**Changes**
* Pages now have better responsiveness, down until 1150px width. Below that width, the page will overflow to not break the layout. (more work is needed to make the pages fully responsive. Need to design where to put the side menu, etc.)
* On mobile, it will render as a desktop page with a width of 1150px. Doesn't look good, but at least the page layout doesn't break and visitors can zoom in and navigate.
* Added page titles to all pages.

1440px
![image](https://user-images.githubusercontent.com/12248320/111892180-7b9c2b80-89cf-11eb-8f96-55bf84385da9.png)

1150px
![image](https://user-images.githubusercontent.com/12248320/111892230-e3eb0d00-89cf-11eb-9e44-d27b899badf4.png)

800px
![image](https://user-images.githubusercontent.com/12248320/111892235-efd6cf00-89cf-11eb-80d7-50c6201b6827.png)

Mobile
![image](https://user-images.githubusercontent.com/12248320/111892345-ffa2e300-89d0-11eb-89c1-d8df54af5a2e.png)

